### PR TITLE
Remove usings where not necessary.

### DIFF
--- a/PayPalAdaptivePaymentsSDK/AdaptivePayments/AdaptivePaymentsService.cs
+++ b/PayPalAdaptivePaymentsSDK/AdaptivePayments/AdaptivePaymentsService.cs
@@ -1,10 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Xml;
-using PayPal;
 using PayPal.Authentication;
 using PayPal.Util;
-using PayPal.Manager;
 using PayPal.NVP;
 using PayPal.AdaptivePayments.Model;
 
@@ -12,11 +8,6 @@ namespace PayPal.AdaptivePayments
 {
 	public partial class AdaptivePaymentsService : BasePayPalService 
 	{
-
-		/// <summary>
-		/// Service Version
-		/// </summary>
-		private const string ServiceVersion = "1.8.7";
 
 		/// <summary>
 		/// Service Name

--- a/PayPalAdaptivePaymentsSDK/AdaptivePayments/PayPalAdaptivePaymentsModel.cs
+++ b/PayPalAdaptivePaymentsSDK/AdaptivePayments/PayPalAdaptivePaymentsModel.cs
@@ -3,15 +3,11 @@
  * AUTO_GENERATED_CODE 
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Web;
-using System.Xml;
-using PayPal.Util;
 
 namespace PayPal.AdaptivePayments.Model
 {

--- a/PayPalAdaptivePaymentsSDK/PayPalAdaptivePaymentsSDK.csproj
+++ b/PayPalAdaptivePaymentsSDK/PayPalAdaptivePaymentsSDK.csproj
@@ -40,11 +40,7 @@
       <HintPath>lib\PayPalCoreSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdaptivePayments\AdaptivePaymentsService.cs" />


### PR DESCRIPTION
Look's like api is deprecated. (Visual studio 2005, .net 2.0, commit frequency)
 If it is true maybe it will be reasonable to add information in *.md file like it was in "https://github.com/paypal/merchant-sdk-dotnet" about deprecation.